### PR TITLE
[#6] [Integrate] As a user, I can see a Progress HUD

### DIFF
--- a/ios/KMMIC/Sources/Presentation/Views/ProgressHUD.swift
+++ b/ios/KMMIC/Sources/Presentation/Views/ProgressHUD.swift
@@ -8,7 +8,22 @@
 
 import SwiftUI
 
+private struct ProgressHUDModifier: ViewModifier {
+
+    let isPresented: Binding<Bool>
+
+    func body(content: Content) -> some View {
+        ZStack {
+            content
+            ProgressHUD(isPresented: isPresented)
+        }
+        .ignoresSafeArea()
+    }
+}
+
 struct ProgressHUD: View {
+
+    @Binding var isPresented: Bool
 
     var body: some View {
         HStack {
@@ -29,17 +44,23 @@ struct ProgressHUD: View {
         )
         .background(Color.black.opacity(0.3))
         .ignoresSafeArea()
+        .opacity(isPresented ? 1.0 : 0.0)
+        .animation(.easeIn(duration: 0.3), value: isPresented)
+    }
+}
+
+extension View {
+
+    func progressHUD(_ isPresented: Binding<Bool>) -> some View {
+        modifier(ProgressHUDModifier(isPresented: isPresented))
     }
 }
 
 struct ProgressHUD_Previews: PreviewProvider {
     static var previews: some View {
-        ZStack {
-            Image(R.image.appBackground.name)
-                .resizable()
-                .aspectRatio(contentMode: .fill)
-            ProgressHUD()
-        }
-        .ignoresSafeArea()
+        Image(R.image.appBackground.name)
+            .resizable()
+            .aspectRatio(contentMode: .fill)
+            .progressHUD(.constant(true))
     }
 }


### PR DESCRIPTION
https://github.com/markgravity/kmm-ic/issues/6

## What happened 👀

- Add `ProgressHUDModifier` to modify the view and toggle Progress HUD
- Extend `View` with the new `ProgressHUDModifier`

## Insight 📝

Please use this example code to have a quick demo of this integration

```swift
// App.swift
@main
struct KMMApp: App {

    @UIApplicationDelegateAdaptor private var appDelegate: AppDelegate

    @State var isPresented: Bool = false
    var body: some Scene {
        WindowGroup {
            VStack {
                // TODO: Remove demo
                Text(Greeting().greet())
                Button("Show Progress HUD") {
                    isPresented.toggle()
                    DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
                        isPresented.toggle()
                    }
                }
            }
            .progressHUD($isPresented)
        }
    }
}
```
## Proof Of Work 📹


https://user-images.githubusercontent.com/17875522/231684966-0f397b2f-d2f5-444a-812f-ac40d45914e0.mp4


