### PR TITLE
[#74] [Chore] Refactor to use invoke operator in Kotlin and callAsFunction in Swift

### DIFF
--- a/ios/KMMIC.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/KMMIC.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,15 +1,6 @@
 {
   "pins" : [
     {
-      "identity" : "nuke",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/kean/Nuke",
-      "state" : {
-        "revision" : "f4d9b95788679d0654c032961f73e7e9c16ca6b4",
-        "version" : "12.1.0"
-      }
-    },
-    {
       "identity" : "testablecombinepublishers",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/albertbori/TestableCombinePublishers",

--- a/ios/KMMIC.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/KMMIC.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,6 +1,15 @@
 {
   "pins" : [
     {
+      "identity" : "nuke",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kean/Nuke",
+      "state" : {
+        "revision" : "f4d9b95788679d0654c032961f73e7e9c16ca6b4",
+        "version" : "12.1.0"
+      }
+    },
+    {
       "identity" : "testablecombinepublishers",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/albertbori/TestableCombinePublishers",

--- a/ios/KMMIC/Sources/Application/App.swift
+++ b/ios/KMMIC/Sources/Application/App.swift
@@ -7,17 +7,14 @@
 //  Copyright © 2023 Nimble. All rights reserved.
 //
 
-import KMPNativeCoroutinesCombine
-import KMPNativeCoroutinesCore
 import Shared
 import SwiftUI
-import Combine
 
 @main
 struct KMMApp: App {
 
     @UIApplicationDelegateAdaptor private var appDelegate: AppDelegate
-    var subscription: AnyCancellable?
+
     var body: some Scene {
         WindowGroup {
             NavigatorStack()

--- a/ios/KMMIC/Sources/Presentation/Modules/Login/LoginViewModel.swift
+++ b/ios/KMMIC/Sources/Presentation/Modules/Login/LoginViewModel.swift
@@ -31,7 +31,7 @@ final class LoginViewModel: ObservableObject {
     func login() {
         isLoading = true
 
-        loginUseCase.invokeAsPublisher(email: email, password: password)
+        loginUseCase(email: email, password: password)
             .receive(on: RunLoop.main)
             .sink { [weak self] result in
                 guard let self else { return }

--- a/ios/tools/sourcery/templates/AutoSharedUseCase.stencil
+++ b/ios/tools/sourcery/templates/AutoSharedUseCase.stencil
@@ -7,7 +7,7 @@ import Combine
 // sourcery:begin: AutoMockable
 extension {{ type.name }} {
 
-  func invokeAsPublisher(
+  func callAsFunction(
     {% for parameter in method.parameters %}
     {{ parameter.asSource }}{% if not forloop.last %},{% endif %}
     {% endfor %}

--- a/shared/src/commonMain/kotlin/co/nimblehq/mark/kmmic/di/DI.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/mark/kmmic/di/DI.kt
@@ -43,6 +43,6 @@ fun init() {
     }
 
     startKoin {
-        modules(listOf(commonModule, dataModule, domainModule))
+        modules(commonModule + dataModule + domainModule)
     }
 }

--- a/shared/src/commonMain/kotlin/co/nimblehq/mark/kmmic/domain/usecase/GetCurrentUserUseCase.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/mark/kmmic/domain/usecase/GetCurrentUserUseCase.kt
@@ -7,7 +7,7 @@ import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
 interface GetCurrentUserUseCase {
-    fun invoke(): Flow<User>
+    operator fun invoke(): Flow<User>
 }
 
 class GetCurrentUserUseCaseImpl : GetCurrentUserUseCase, KoinComponent {

--- a/shared/src/commonMain/kotlin/co/nimblehq/mark/kmmic/domain/usecase/LoginUseCase.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/mark/kmmic/domain/usecase/LoginUseCase.kt
@@ -8,7 +8,7 @@ import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
 interface LoginUseCase {
-    fun invoke(email: String, password: String): Flow<AuthToken>
+    operator fun invoke(email: String, password: String): Flow<AuthToken>
 }
 
 class LoginUseCaseImpl : LoginUseCase, KoinComponent {

--- a/shared/src/commonTest/kotlin/co/nimblehq/mark/kmmic/domain/usecase/GetCurrentUserUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/co/nimblehq/mark/kmmic/domain/usecase/GetCurrentUserUseCaseTest.kt
@@ -9,6 +9,7 @@ import io.mockative.classOf
 import io.mockative.given
 import io.mockative.mock
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 import org.koin.core.context.startKoin
 import org.koin.dsl.module

--- a/shared/src/commonTest/kotlin/co/nimblehq/mark/kmmic/domain/usecase/GetCurrentUserUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/co/nimblehq/mark/kmmic/domain/usecase/GetCurrentUserUseCaseTest.kt
@@ -57,9 +57,7 @@ class GetCurrentUserUseCaseTest {
                 }
             )
 
-        useCase().collect {
-            it shouldBe mockUser
-        }
+        useCase().first() shouldBe mockUser
     }
 
 }

--- a/shared/src/commonTest/kotlin/co/nimblehq/mark/kmmic/domain/usecase/GetCurrentUserUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/co/nimblehq/mark/kmmic/domain/usecase/GetCurrentUserUseCaseTest.kt
@@ -57,7 +57,7 @@ class GetCurrentUserUseCaseTest {
                 }
             )
 
-        useCase.invoke().collect {
+        useCase().collect {
             it shouldBe mockUser
         }
     }


### PR DESCRIPTION
https://github.com/markgravity/kmm-ic/issues/74

## What happened 👀

- Refactor to use `operator func invoke` in the Kotlin UseCase
- Update the `AutoSharedUseCase.stencil` to generate the UseCase function which uses `callAsFunction` instead
- Remove redundant code in `App.swift`
## Insight 📝

n/a

## Proof Of Work 📹

CI successfully
