### PR TITLE
[#19] [Backend] As a user, I can see a list of surveys on the home screen

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.21")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.10")
         classpath("com.codingfeline.buildkonfig:buildkonfig-gradle-plugin:0.13.3")
         classpath("org.jetbrains.kotlin:kotlin-serialization:1.7.10")
     }

--- a/ios/KMMIC.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/KMMIC.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,6 +1,15 @@
 {
   "pins" : [
     {
+      "identity" : "nuke",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kean/Nuke",
+      "state" : {
+        "revision" : "f4d9b95788679d0654c032961f73e7e9c16ca6b4",
+        "version" : "12.1.0"
+      }
+    },
+    {
       "identity" : "testablecombinepublishers",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/albertbori/TestableCombinePublishers",

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -10,6 +10,7 @@ plugins {
     id("com.codingfeline.buildkonfig")
     id("com.google.devtools.ksp").version("1.7.10-1.0.6")
     id("com.rickclephas.kmp.nativecoroutines").version("0.12.6-new-mm")
+    id("io.realm.kotlin") version "1.3.0"
 }
 
 kotlin {
@@ -66,6 +67,9 @@ kotlin {
                 // Setting
                 implementation("com.russhwolf:multiplatform-settings-no-arg:1.0.0-RC")
                 implementation("com.russhwolf:multiplatform-settings-serialization:1.0.0-RC")
+
+                // Realm
+                implementation("io.realm.kotlin:library-base:1.3.0")
             }
         }
         val commonTest by getting {
@@ -74,6 +78,7 @@ kotlin {
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.4")
                 implementation("io.mockative:mockative:1.4.0")
                 implementation("io.kotest:kotest-framework-engine:5.5.1")
+                implementation("app.cash.turbine:turbine:0.12.3")
             }
         }
         val androidMain by getting

--- a/shared/src/commonMain/kotlin/co/nimblehq/mark/kmmic/data/repository/SurveyRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/mark/kmmic/data/repository/SurveyRepositoryImpl.kt
@@ -1,0 +1,46 @@
+package co.nimblehq.mark.kmmic.data.repository
+
+import co.nimblehq.mark.kmmic.data.service.cached.survey.CachedSurveyService
+import co.nimblehq.mark.kmmic.data.service.cached.survey.model.CachedSurvey
+import co.nimblehq.mark.kmmic.data.service.survey.SurveyService
+import co.nimblehq.mark.kmmic.data.service.survey.model.GetSurveysParams
+import co.nimblehq.mark.kmmic.domain.model.Survey
+import co.nimblehq.mark.kmmic.domain.repository.SurveyRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.last
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+
+private const val FIRST_PAGE_NUMBER = 1
+
+internal class SurveyRepositoryImpl: SurveyRepository, KoinComponent {
+
+    private val surveyService: SurveyService by inject()
+    private val cachedSurveyService: CachedSurveyService by inject()
+
+    override fun getSurveys(
+        pageNumber: Int,
+        pageSize: Int,
+        isRefresh: Boolean
+    ): Flow<List<Survey>> {
+        return flow {
+            if (isRefresh) {
+                cachedSurveyService.clear()
+            }
+
+            if (!isRefresh && pageNumber == FIRST_PAGE_NUMBER) {
+                val surveys = cachedSurveyService.get()
+                    .map { Survey(it) }
+                if (surveys.isNotEmpty()) emit(surveys)
+            }
+
+            val surveys = surveyService
+                .getSurveys(GetSurveysParams(pageNumber, pageSize))
+                .last()
+            emit(surveys.map { Survey(it) })
+
+            cachedSurveyService.save(surveys.map { CachedSurvey(it) })
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/co/nimblehq/mark/kmmic/data/repository/SurveyRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/mark/kmmic/data/repository/SurveyRepositoryImpl.kt
@@ -2,8 +2,11 @@ package co.nimblehq.mark.kmmic.data.repository
 
 import co.nimblehq.mark.kmmic.data.service.cached.survey.CachedSurveyService
 import co.nimblehq.mark.kmmic.data.service.cached.survey.model.CachedSurvey
+import co.nimblehq.mark.kmmic.data.service.cached.survey.model.toSurvey
 import co.nimblehq.mark.kmmic.data.service.survey.SurveyService
 import co.nimblehq.mark.kmmic.data.service.survey.model.GetSurveysParams
+import co.nimblehq.mark.kmmic.data.service.survey.model.toCachedSurvey
+import co.nimblehq.mark.kmmic.data.service.survey.model.toSurvey
 import co.nimblehq.mark.kmmic.domain.model.Survey
 import co.nimblehq.mark.kmmic.domain.repository.SurveyRepository
 import kotlinx.coroutines.flow.Flow
@@ -31,16 +34,16 @@ internal class SurveyRepositoryImpl: SurveyRepository, KoinComponent {
 
             if (!isRefresh && pageNumber == FIRST_PAGE_NUMBER) {
                 val surveys = cachedSurveyService.get()
-                    .map { Survey(it) }
+                    .map { it.toSurvey() }
                 if (surveys.isNotEmpty()) emit(surveys)
             }
 
             val surveys = surveyService
                 .getSurveys(GetSurveysParams(pageNumber, pageSize))
                 .last()
-            emit(surveys.map { Survey(it) })
+            emit(surveys.map { it.toSurvey() })
 
-            cachedSurveyService.save(surveys.map { CachedSurvey(it) })
+            cachedSurveyService.save(surveys.map { it.toCachedSurvey() })
         }
     }
 }

--- a/shared/src/commonMain/kotlin/co/nimblehq/mark/kmmic/data/service/api/serializer/UrlSerializer.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/mark/kmmic/data/service/api/serializer/UrlSerializer.kt
@@ -1,0 +1,26 @@
+package co.nimblehq.mark.kmmic.data.service.api.serializer
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+@Serializable(with = FullSizeUrlSerializer::class)
+class Url(val string: String)
+
+object FullSizeUrlSerializer : KSerializer<Url> {
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("Url", PrimitiveKind.STRING)
+
+    override fun serialize(encoder: Encoder, value: Url) {
+        encoder.encodeString(value.string)
+    }
+
+    override fun deserialize(decoder: Decoder): Url {
+        val string = decoder.decodeString() + "l"
+        return Url(string)
+    }
+}

--- a/shared/src/commonMain/kotlin/co/nimblehq/mark/kmmic/data/service/api/serializer/UrlSerializer.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/mark/kmmic/data/service/api/serializer/UrlSerializer.kt
@@ -15,9 +15,7 @@ object FullSizeUrlSerializer : KSerializer<Url> {
     override val descriptor: SerialDescriptor =
         PrimitiveSerialDescriptor("Url", PrimitiveKind.STRING)
 
-    override fun serialize(encoder: Encoder, value: Url) {
-        encoder.encodeString(value.string)
-    }
+    override fun serialize(encoder: Encoder, value: Url) = encoder.encodeString(value.string)
 
     override fun deserialize(decoder: Decoder): Url {
         val string = decoder.decodeString() + "l"

--- a/shared/src/commonMain/kotlin/co/nimblehq/mark/kmmic/data/service/cached/survey/CachedSurveyService.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/mark/kmmic/data/service/cached/survey/CachedSurveyService.kt
@@ -1,0 +1,39 @@
+package co.nimblehq.mark.kmmic.data.service.cached.survey
+
+import co.nimblehq.mark.kmmic.data.service.cached.survey.model.CachedSurvey
+import io.realm.kotlin.Realm
+import io.realm.kotlin.UpdatePolicy
+import io.realm.kotlin.ext.query
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+
+internal interface CachedSurveyService {
+
+    fun save(surveys: List<CachedSurvey>)
+    fun get(): List<CachedSurvey>
+    fun clear()
+}
+
+internal class CachedSurveyServiceImpl: CachedSurveyService, KoinComponent {
+
+    private val realm: Realm by inject()
+
+    override fun save(surveys: List<CachedSurvey>) {
+        realm.writeBlocking {
+            surveys.forEach {
+                copyToRealm(it, updatePolicy = UpdatePolicy.ALL)
+            }
+        }
+    }
+
+    override fun get(): List<CachedSurvey> {
+        return listOf()
+    }
+
+    override fun clear() {
+        realm.writeBlocking {
+            val surveys = query<CachedSurvey>().find()
+            delete(surveys)
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/co/nimblehq/mark/kmmic/data/service/cached/survey/CachedSurveyService.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/mark/kmmic/data/service/cached/survey/CachedSurveyService.kt
@@ -26,9 +26,7 @@ internal class CachedSurveyServiceImpl: CachedSurveyService, KoinComponent {
         }
     }
 
-    override fun get(): List<CachedSurvey> {
-        return realm.query<CachedSurvey>().find()
-    }
+    override fun get(): List<CachedSurvey> = realm.query<CachedSurvey>().find()
 
     override fun clear() {
         realm.writeBlocking {

--- a/shared/src/commonMain/kotlin/co/nimblehq/mark/kmmic/data/service/cached/survey/CachedSurveyService.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/mark/kmmic/data/service/cached/survey/CachedSurveyService.kt
@@ -27,7 +27,7 @@ internal class CachedSurveyServiceImpl: CachedSurveyService, KoinComponent {
     }
 
     override fun get(): List<CachedSurvey> {
-        return listOf()
+        return realm.query<CachedSurvey>().find()
     }
 
     override fun clear() {

--- a/shared/src/commonMain/kotlin/co/nimblehq/mark/kmmic/data/service/cached/survey/model/CachedSurvey.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/mark/kmmic/data/service/cached/survey/model/CachedSurvey.kt
@@ -1,9 +1,10 @@
 package co.nimblehq.mark.kmmic.data.service.cached.survey.model
 
-import co.nimblehq.mark.kmmic.data.service.survey.model.SurveyApiModel
+import co.nimblehq.mark.kmmic.domain.model.Survey
 import io.realm.kotlin.types.RealmObject
 import io.realm.kotlin.types.annotations.PrimaryKey
 
+@Suppress("LongParameterList")
 internal class CachedSurvey() : RealmObject {
 
     @PrimaryKey
@@ -14,12 +15,27 @@ internal class CachedSurvey() : RealmObject {
     var isActive: Boolean = false
     var coverImageUrl: String = ""
 
-    constructor(surveyApiModel: SurveyApiModel) : this() {
-        this.id = surveyApiModel.id
-        this.type = surveyApiModel.type
-        this.title = surveyApiModel.title
-        this.description = surveyApiModel.description
-        this.isActive = surveyApiModel.isActive
-        this.coverImageUrl = surveyApiModel.coverImageUrl.string
+    constructor(
+        id: String,
+        type: String,
+        title: String,
+        description: String,
+        isActive: Boolean,
+        coverImageUrl: String
+    ) : this() {
+        this.id = id
+        this.type = type
+        this.title = title
+        this.description = description
+        this.isActive = isActive
+        this.coverImageUrl = coverImageUrl
     }
 }
+
+internal fun CachedSurvey.toSurvey() = Survey(
+    id,
+    title,
+    description,
+    isActive,
+    coverImageUrl
+)

--- a/shared/src/commonMain/kotlin/co/nimblehq/mark/kmmic/data/service/cached/survey/model/CachedSurvey.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/mark/kmmic/data/service/cached/survey/model/CachedSurvey.kt
@@ -1,0 +1,25 @@
+package co.nimblehq.mark.kmmic.data.service.cached.survey.model
+
+import co.nimblehq.mark.kmmic.data.service.survey.model.SurveyApiModel
+import io.realm.kotlin.types.RealmObject
+import io.realm.kotlin.types.annotations.PrimaryKey
+
+internal class CachedSurvey() : RealmObject {
+
+    @PrimaryKey
+    var id: String = ""
+    var type: String = ""
+    var title: String = ""
+    var description: String = ""
+    var isActive: Boolean = false
+    var coverImageUrl: String = ""
+
+    constructor(surveyApiModel: SurveyApiModel) : this() {
+        this.id = surveyApiModel.id
+        this.type = surveyApiModel.type
+        this.title = surveyApiModel.title
+        this.description = surveyApiModel.description
+        this.isActive = surveyApiModel.isActive
+        this.coverImageUrl = surveyApiModel.coverImageUrl.string
+    }
+}

--- a/shared/src/commonMain/kotlin/co/nimblehq/mark/kmmic/data/service/survey/SurveyService.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/mark/kmmic/data/service/survey/SurveyService.kt
@@ -1,0 +1,32 @@
+package co.nimblehq.mark.kmmic.data.service.survey
+
+import co.nimblehq.mark.kmmic.data.service.api.ApiService
+import co.nimblehq.mark.kmmic.data.service.api.extension.path
+import co.nimblehq.mark.kmmic.data.service.api.extension.setQueryParameters
+import co.nimblehq.mark.kmmic.data.service.survey.model.GetSurveysParams
+import co.nimblehq.mark.kmmic.data.service.survey.model.SurveyApiModel
+import io.ktor.client.request.HttpRequestBuilder
+import io.ktor.http.HttpMethod
+import kotlinx.coroutines.flow.Flow
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+
+internal interface SurveyService {
+
+    fun getSurveys(params: GetSurveysParams): Flow<List<SurveyApiModel>>
+}
+
+internal class SurveyServiceImpl: SurveyService, KoinComponent {
+
+    private val apiService: ApiService by inject()
+
+    override fun getSurveys(params: GetSurveysParams): Flow<List<SurveyApiModel>> {
+        return apiService.performRequest<List<SurveyApiModel>>(
+            HttpRequestBuilder().apply {
+                path("/v1/surveys")
+                method = HttpMethod.Get
+                setQueryParameters(params)
+            }
+        )
+    }
+}

--- a/shared/src/commonMain/kotlin/co/nimblehq/mark/kmmic/data/service/survey/model/GetSurveysParams.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/mark/kmmic/data/service/survey/model/GetSurveysParams.kt
@@ -1,0 +1,12 @@
+package co.nimblehq.mark.kmmic.data.service.survey.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+internal data class GetSurveysParams(
+    @SerialName("page[number]")
+    val pageNumber: Int,
+    @SerialName("page[size]")
+    val pageSize: Int
+)

--- a/shared/src/commonMain/kotlin/co/nimblehq/mark/kmmic/data/service/survey/model/SurveyApiModel.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/mark/kmmic/data/service/survey/model/SurveyApiModel.kt
@@ -1,6 +1,7 @@
 package co.nimblehq.mark.kmmic.data.service.survey.model
 
 import co.nimblehq.mark.kmmic.data.service.api.serializer.Url
+import co.nimblehq.mark.kmmic.data.service.cached.survey.model.CachedSurvey
 import co.nimblehq.mark.kmmic.domain.model.Survey
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -19,4 +20,21 @@ internal data class SurveyApiModel(
     val isActive: Boolean,
     @SerialName("cover_image_url")
     val coverImageUrl: Url
+)
+
+internal fun SurveyApiModel.toSurvey() = Survey(
+    id,
+    title,
+    description,
+    isActive,
+    coverImageUrl.string
+)
+
+internal fun SurveyApiModel.toCachedSurvey() = CachedSurvey(
+    id = id,
+    type = type,
+    title = title,
+    description = description,
+    isActive = isActive,
+    coverImageUrl = coverImageUrl.string
 )

--- a/shared/src/commonMain/kotlin/co/nimblehq/mark/kmmic/data/service/survey/model/SurveyApiModel.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/mark/kmmic/data/service/survey/model/SurveyApiModel.kt
@@ -1,0 +1,22 @@
+package co.nimblehq.mark.kmmic.data.service.survey.model
+
+import co.nimblehq.mark.kmmic.data.service.api.serializer.Url
+import co.nimblehq.mark.kmmic.domain.model.Survey
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+internal data class SurveyApiModel(
+    @SerialName("id")
+    val id: String,
+    @SerialName("type")
+    val type: String,
+    @SerialName("title")
+    val title: String,
+    @SerialName("description")
+    val description: String,
+    @SerialName("is_active")
+    val isActive: Boolean,
+    @SerialName("cover_image_url")
+    val coverImageUrl: Url
+)

--- a/shared/src/commonMain/kotlin/co/nimblehq/mark/kmmic/di/DI.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/mark/kmmic/di/DI.kt
@@ -1,21 +1,30 @@
 package co.nimblehq.mark.kmmic.di
 
 import co.nimblehq.mark.kmmic.data.repository.AuthRepositoryImpl
+import co.nimblehq.mark.kmmic.data.repository.SurveyRepositoryImpl
 import co.nimblehq.mark.kmmic.data.repository.UserRepositoryImpl
 import co.nimblehq.mark.kmmic.data.service.api.ApiService
 import co.nimblehq.mark.kmmic.data.service.auth.AuthService
 import co.nimblehq.mark.kmmic.data.service.auth.AuthServiceImpl
+import co.nimblehq.mark.kmmic.data.service.cached.survey.CachedSurveyService
+import co.nimblehq.mark.kmmic.data.service.cached.survey.CachedSurveyServiceImpl
+import co.nimblehq.mark.kmmic.data.service.cached.survey.model.CachedSurvey
+import co.nimblehq.mark.kmmic.data.service.survey.SurveyService
+import co.nimblehq.mark.kmmic.data.service.survey.SurveyServiceImpl
 import co.nimblehq.mark.kmmic.data.service.token.TokenService
 import co.nimblehq.mark.kmmic.data.service.token.TokenServiceImpl
 import co.nimblehq.mark.kmmic.data.service.user.UserService
 import co.nimblehq.mark.kmmic.data.service.user.UserServiceImpl
 import co.nimblehq.mark.kmmic.domain.repository.AuthRepository
+import co.nimblehq.mark.kmmic.domain.repository.SurveyRepository
 import co.nimblehq.mark.kmmic.domain.repository.UserRepository
 import co.nimblehq.mark.kmmic.domain.usecase.GetCurrentUserUseCase
 import co.nimblehq.mark.kmmic.domain.usecase.GetCurrentUserUseCaseImpl
 import co.nimblehq.mark.kmmic.domain.usecase.LoginUseCase
 import co.nimblehq.mark.kmmic.domain.usecase.LoginUseCaseImpl
 import com.russhwolf.settings.Settings
+import io.realm.kotlin.Realm
+import io.realm.kotlin.RealmConfiguration
 import org.koin.core.context.startKoin
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
@@ -24,7 +33,11 @@ const val UNAUTHORIZED_API_SERVICE_NAME = "UNAUTHORIZED_API_CLIENT"
 
 fun init() {
     val commonModule = module {
-        factory { Settings() }
+        single { Settings() }
+        single {
+            val configuration = RealmConfiguration.create(schema = setOf(CachedSurvey::class))
+            Realm.open(configuration)
+        }
     }
 
     val dataModule = module {
@@ -35,6 +48,9 @@ fun init() {
         factory<AuthRepository> { AuthRepositoryImpl() }
         factory<UserService> { UserServiceImpl() }
         factory<UserRepository> { UserRepositoryImpl() }
+        factory<SurveyService> { SurveyServiceImpl() }
+        factory<CachedSurveyService> { CachedSurveyServiceImpl() }
+        factory<SurveyRepository> { SurveyRepositoryImpl() }
     }
 
     val domainModule = module {

--- a/shared/src/commonMain/kotlin/co/nimblehq/mark/kmmic/domain/model/Survey.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/mark/kmmic/domain/model/Survey.kt
@@ -1,0 +1,30 @@
+package co.nimblehq.mark.kmmic.domain.model
+
+import co.nimblehq.mark.kmmic.data.service.cached.survey.model.CachedSurvey
+import co.nimblehq.mark.kmmic.data.service.survey.model.SurveyApiModel
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Survey(
+    val id: String,
+    val title: String,
+    val description: String,
+    val isActive: Boolean,
+    val coverImageUrl: String
+) {
+    internal constructor(surveyApiModel: SurveyApiModel) : this(
+        surveyApiModel.id,
+        surveyApiModel.title,
+        surveyApiModel.description,
+        surveyApiModel.isActive,
+        surveyApiModel.coverImageUrl.string
+    )
+
+    internal constructor(cachedSurvey: CachedSurvey) : this(
+        cachedSurvey.id,
+        cachedSurvey.title,
+        cachedSurvey.description,
+        cachedSurvey.isActive,
+        cachedSurvey.coverImageUrl
+    )
+}

--- a/shared/src/commonMain/kotlin/co/nimblehq/mark/kmmic/domain/model/Survey.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/mark/kmmic/domain/model/Survey.kt
@@ -1,7 +1,5 @@
 package co.nimblehq.mark.kmmic.domain.model
 
-import co.nimblehq.mark.kmmic.data.service.cached.survey.model.CachedSurvey
-import co.nimblehq.mark.kmmic.data.service.survey.model.SurveyApiModel
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -11,20 +9,4 @@ data class Survey(
     val description: String,
     val isActive: Boolean,
     val coverImageUrl: String
-) {
-    internal constructor(surveyApiModel: SurveyApiModel) : this(
-        surveyApiModel.id,
-        surveyApiModel.title,
-        surveyApiModel.description,
-        surveyApiModel.isActive,
-        surveyApiModel.coverImageUrl.string
-    )
-
-    internal constructor(cachedSurvey: CachedSurvey) : this(
-        cachedSurvey.id,
-        cachedSurvey.title,
-        cachedSurvey.description,
-        cachedSurvey.isActive,
-        cachedSurvey.coverImageUrl
-    )
-}
+)

--- a/shared/src/commonMain/kotlin/co/nimblehq/mark/kmmic/domain/repository/SurveyRepository.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/mark/kmmic/domain/repository/SurveyRepository.kt
@@ -1,0 +1,14 @@
+package co.nimblehq.mark.kmmic.domain.repository
+
+import co.nimblehq.mark.kmmic.domain.model.Survey
+import co.nimblehq.mark.kmmic.domain.model.User
+import kotlinx.coroutines.flow.Flow
+
+internal interface SurveyRepository {
+
+    fun getSurveys(
+        pageNumber: Int,
+        pageSize: Int,
+        isRefresh: Boolean
+    ): Flow<List<Survey>>
+}

--- a/shared/src/commonMain/kotlin/co/nimblehq/mark/kmmic/domain/usecase/GetSurveysUseCase.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/mark/kmmic/domain/usecase/GetSurveysUseCase.kt
@@ -1,0 +1,25 @@
+package co.nimblehq.mark.kmmic.domain.usecase
+
+import co.nimblehq.mark.kmmic.domain.model.AuthToken
+import co.nimblehq.mark.kmmic.domain.model.Survey
+import co.nimblehq.mark.kmmic.domain.repository.AuthRepository
+import co.nimblehq.mark.kmmic.domain.repository.SurveyRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.onEach
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+
+interface GetSurveysUseCase {
+
+    operator fun invoke(pageNumber: Int, pageSize: Int, isRefresh: Boolean): Flow<List<Survey>>
+}
+
+class GetSurveysUseCaseImpl : GetSurveysUseCase, KoinComponent {
+
+    private val surveyRepository: SurveyRepository by inject()
+
+    override fun invoke(pageNumber: Int, pageSize: Int, isRefresh: Boolean): Flow<List<Survey>> {
+        return surveyRepository
+            .getSurveys(pageNumber, pageSize, isRefresh)
+    }
+}

--- a/shared/src/commonTest/kotlin/co/nimblehq/mark/kmmic/data/repository/SurveyRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/co/nimblehq/mark/kmmic/data/repository/SurveyRepositoryTest.kt
@@ -5,6 +5,8 @@ import co.nimblehq.mark.kmmic.data.service.cached.survey.CachedSurveyService
 import co.nimblehq.mark.kmmic.data.service.cached.survey.model.CachedSurvey
 import co.nimblehq.mark.kmmic.data.service.survey.SurveyService
 import co.nimblehq.mark.kmmic.data.service.survey.model.SurveyApiModel
+import co.nimblehq.mark.kmmic.data.service.survey.model.toCachedSurvey
+import co.nimblehq.mark.kmmic.data.service.survey.model.toSurvey
 import co.nimblehq.mark.kmmic.domain.model.Survey
 import co.nimblehq.mark.kmmic.domain.repository.SurveyRepository
 import co.nimblehq.mark.kmmic.dummy.dummy
@@ -32,8 +34,8 @@ class SurveyRepositoryTest {
     private val mockCachedSurveyService = mock(classOf<CachedSurveyService>())
     private val mockThrowable = Throwable("mock")
     private val mockSurveyApiModel = SurveyApiModel.dummy
-    private val mockCachedSurvey = CachedSurvey(mockSurveyApiModel)
-    private val mockSurvey = Survey(mockSurveyApiModel)
+    private val mockCachedSurvey = mockSurveyApiModel.toCachedSurvey()
+    private val mockSurvey = mockSurveyApiModel.toSurvey()
 
     @BeforeTest
     fun setUp() {

--- a/shared/src/commonTest/kotlin/co/nimblehq/mark/kmmic/data/repository/SurveyRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/co/nimblehq/mark/kmmic/data/repository/SurveyRepositoryTest.kt
@@ -24,16 +24,16 @@ import kotlin.test.AfterTest
 @ExperimentalCoroutinesApi
 class SurveyRepositoryTest {
 
+    private lateinit var repository: SurveyRepository
+
     @Mock
     private val mockSurveyService = mock(classOf<SurveyService>())
     @Mock
     private val mockCachedSurveyService = mock(classOf<CachedSurveyService>())
-
     private val mockThrowable = Throwable("mock")
-    private lateinit var repository: SurveyRepository
     private val mockSurveyApiModel = SurveyApiModel.dummy
     private val mockCachedSurvey = CachedSurvey(mockSurveyApiModel)
-    private  val mockSurvey = Survey(mockSurveyApiModel)
+    private val mockSurvey = Survey(mockSurveyApiModel)
 
     @BeforeTest
     fun setUp() {

--- a/shared/src/commonTest/kotlin/co/nimblehq/mark/kmmic/data/repository/SurveyRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/co/nimblehq/mark/kmmic/data/repository/SurveyRepositoryTest.kt
@@ -1,0 +1,124 @@
+package co.nimblehq.mark.kmmic.data.repository
+
+import app.cash.turbine.test
+import co.nimblehq.mark.kmmic.data.service.cached.survey.CachedSurveyService
+import co.nimblehq.mark.kmmic.data.service.cached.survey.model.CachedSurvey
+import co.nimblehq.mark.kmmic.data.service.survey.SurveyService
+import co.nimblehq.mark.kmmic.data.service.survey.model.SurveyApiModel
+import co.nimblehq.mark.kmmic.domain.model.Survey
+import co.nimblehq.mark.kmmic.domain.repository.SurveyRepository
+import co.nimblehq.mark.kmmic.dummy.dummy
+import kotlin.test.BeforeTest
+import io.kotest.matchers.shouldBe
+import io.mockative.*
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import org.koin.core.context.startKoin
+import org.koin.dsl.module
+import kotlin.test.Test
+import kotlinx.coroutines.test.runTest
+import org.koin.core.context.stopKoin
+import kotlin.test.AfterTest
+
+@ExperimentalCoroutinesApi
+class SurveyRepositoryTest {
+
+    @Mock
+    private val mockSurveyService = mock(classOf<SurveyService>())
+    @Mock
+    private val mockCachedSurveyService = mock(classOf<CachedSurveyService>())
+
+    private val mockThrowable = Throwable("mock")
+    private lateinit var repository: SurveyRepository
+    private val mockSurveyApiModel = SurveyApiModel.dummy
+    private val mockCachedSurvey = CachedSurvey(mockSurveyApiModel)
+    private  val mockSurvey = Survey(mockSurveyApiModel)
+
+    @BeforeTest
+    fun setUp() {
+        startKoin{
+            modules(
+                module {
+                    single { mockSurveyService }
+                    single { mockCachedSurveyService }
+                }
+            )
+        }
+
+        repository = SurveyRepositoryImpl()
+    }
+
+    @AfterTest
+    fun tearDown() {
+        stopKoin()
+    }
+
+    @Test
+    fun `when there is no cached survey and get surveys is succeeded - it emits surveys once`() = runTest {
+        given(mockSurveyService)
+            .function(mockSurveyService::getSurveys)
+            .whenInvokedWith(any())
+            .thenReturn(flowOf(listOf(mockSurveyApiModel)))
+        given(mockCachedSurveyService)
+            .function(mockCachedSurveyService::get)
+            .whenInvoked()
+            .thenReturn(listOf())
+
+        repository.getSurveys(1, 1, false).test {
+            this.awaitItem() shouldBe listOf(mockSurvey)
+            this.awaitComplete()
+        }
+    }
+
+    @Test
+    fun `when there is cached survey and get surveys is succeeded - it emits surveys twice`() = runTest {
+        given(mockSurveyService)
+            .function(mockSurveyService::getSurveys)
+            .whenInvokedWith(any())
+            .thenReturn(flowOf(listOf(mockSurveyApiModel)))
+        given(mockCachedSurveyService)
+            .function(mockCachedSurveyService::get)
+            .whenInvoked()
+            .thenReturn(listOf(mockCachedSurvey))
+
+        repository.getSurveys(1, 1, false).test {
+            this.awaitItem() shouldBe listOf(mockSurvey)
+            this.awaitItem() shouldBe listOf(mockSurvey)
+            this.awaitComplete()
+        }
+    }
+
+    @Test
+    fun `when refreshing and get surveys is succeeded - it emits surveys once from API`() = runTest {
+        given(mockSurveyService)
+            .function(mockSurveyService::getSurveys)
+            .whenInvokedWith(any())
+            .thenReturn(flowOf(listOf(mockSurveyApiModel)))
+
+        repository.getSurveys(1, 1, true).test {
+            this.awaitItem() shouldBe listOf(mockSurvey)
+            this.awaitComplete()
+        }
+
+        verify(mockCachedSurveyService)
+            .function(mockCachedSurveyService::clear)
+            .wasInvoked(exactly = 1.times)
+    }
+
+    @Test
+    fun `when get surveys is failed - it emits error`() = runTest {
+        given(mockSurveyService)
+            .function(mockSurveyService::getSurveys)
+            .whenInvokedWith(any())
+            .thenReturn(
+                flow {
+                    throw mockThrowable
+                }
+            )
+
+        repository.getSurveys(1, 1, true).test {
+            this.awaitError().message shouldBe mockThrowable.message
+        }
+    }
+}

--- a/shared/src/commonTest/kotlin/co/nimblehq/mark/kmmic/domain/usecase/GetSurveysUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/co/nimblehq/mark/kmmic/domain/usecase/GetSurveysUseCaseTest.kt
@@ -1,0 +1,56 @@
+package co.nimblehq.mark.kmmic.domain.usecase
+
+import co.nimblehq.mark.kmmic.data.service.survey.model.SurveyApiModel
+import co.nimblehq.mark.kmmic.domain.model.Survey
+import co.nimblehq.mark.kmmic.domain.repository.SurveyRepository
+import co.nimblehq.mark.kmmic.dummy.dummy
+import kotlin.test.BeforeTest
+import io.kotest.matchers.shouldBe
+import io.mockative.*
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import org.koin.core.context.startKoin
+import org.koin.dsl.module
+import kotlin.test.Test
+import kotlinx.coroutines.test.runTest
+import org.koin.core.context.stopKoin
+import kotlin.test.AfterTest
+
+@ExperimentalCoroutinesApi
+class GetSurveysUseCaseTest {
+
+    @Mock
+    private val mockSurveyRepository = mock(classOf<SurveyRepository>())
+    private lateinit var useCase: GetSurveysUseCase
+    private val mockSurvey = Survey(SurveyApiModel.dummy)
+
+    @BeforeTest
+    fun setUp() {
+        startKoin{
+            modules(
+                module {
+                    single { mockSurveyRepository }
+                }
+            )
+        }
+
+        useCase = GetSurveysUseCaseImpl()
+    }
+
+    @AfterTest
+    fun tearDown() {
+        stopKoin()
+    }
+
+    @Test
+    fun `when invoke is called - it returns the correctly surveys`() = runTest {
+        given(mockSurveyRepository)
+            .function(mockSurveyRepository::getSurveys)
+            .whenInvokedWith(any())
+            .thenReturn(flowOf(listOf(mockSurvey)))
+
+        useCase(1, 1, false).collect {
+            it shouldBe listOf(mockSurvey)
+        }
+    }
+}

--- a/shared/src/commonTest/kotlin/co/nimblehq/mark/kmmic/domain/usecase/GetSurveysUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/co/nimblehq/mark/kmmic/domain/usecase/GetSurveysUseCaseTest.kt
@@ -8,6 +8,7 @@ import kotlin.test.BeforeTest
 import io.kotest.matchers.shouldBe
 import io.mockative.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import org.koin.core.context.startKoin
 import org.koin.dsl.module
@@ -19,9 +20,10 @@ import kotlin.test.AfterTest
 @ExperimentalCoroutinesApi
 class GetSurveysUseCaseTest {
 
+    private lateinit var useCase: GetSurveysUseCase
+
     @Mock
     private val mockSurveyRepository = mock(classOf<SurveyRepository>())
-    private lateinit var useCase: GetSurveysUseCase
     private val mockSurvey = Survey(SurveyApiModel.dummy)
 
     @BeforeTest
@@ -43,14 +45,12 @@ class GetSurveysUseCaseTest {
     }
 
     @Test
-    fun `when invoke is called - it returns the correctly surveys`() = runTest {
+    fun `when invoke is called - it returns surveys correctly`() = runTest {
         given(mockSurveyRepository)
             .function(mockSurveyRepository::getSurveys)
             .whenInvokedWith(any())
             .thenReturn(flowOf(listOf(mockSurvey)))
 
-        useCase(1, 1, false).collect {
-            it shouldBe listOf(mockSurvey)
-        }
+        useCase(1, 1, false).first() shouldBe listOf(mockSurvey)
     }
 }

--- a/shared/src/commonTest/kotlin/co/nimblehq/mark/kmmic/domain/usecase/GetSurveysUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/co/nimblehq/mark/kmmic/domain/usecase/GetSurveysUseCaseTest.kt
@@ -1,6 +1,7 @@
 package co.nimblehq.mark.kmmic.domain.usecase
 
 import co.nimblehq.mark.kmmic.data.service.survey.model.SurveyApiModel
+import co.nimblehq.mark.kmmic.data.service.survey.model.toSurvey
 import co.nimblehq.mark.kmmic.domain.model.Survey
 import co.nimblehq.mark.kmmic.domain.repository.SurveyRepository
 import co.nimblehq.mark.kmmic.dummy.dummy
@@ -24,7 +25,7 @@ class GetSurveysUseCaseTest {
 
     @Mock
     private val mockSurveyRepository = mock(classOf<SurveyRepository>())
-    private val mockSurvey = Survey(SurveyApiModel.dummy)
+    private val mockSurvey = SurveyApiModel.dummy.toSurvey()
 
     @BeforeTest
     fun setUp() {

--- a/shared/src/commonTest/kotlin/co/nimblehq/mark/kmmic/dummy/SurveyApiModel.kt
+++ b/shared/src/commonTest/kotlin/co/nimblehq/mark/kmmic/dummy/SurveyApiModel.kt
@@ -1,0 +1,14 @@
+package co.nimblehq.mark.kmmic.dummy
+
+import co.nimblehq.mark.kmmic.data.service.api.serializer.Url
+import co.nimblehq.mark.kmmic.data.service.survey.model.SurveyApiModel
+
+internal val SurveyApiModel.Companion.dummy
+    get() = SurveyApiModel(
+        "id",
+        "type",
+        "title",
+        "description",
+        true,
+        Url("https://www.example.com/image.png")
+    )


### PR DESCRIPTION
https://github.com/markgravity/kmm-ic/issues/19

## What happened 👀

- Add `SurveyRepository`, `SurveySevice`, `CachedSurveyService` & `GetSurveysUseCase`
- Write UnitTest for `SurveyRepository` & `GetSurveysUseCase`

## Insight 📝

Please accept the unrelate file: [Package.resolved](https://github.com/markgravity/kmm-ic/pull/78#diff-0497307c97cedbd5c3599c03c8e39e0f7e5826c38887a3e3c1bea1702b7acd18), I discard the change on the local but the Xcode keeps update it to match with new package 🙏 

## Proof Of Work 📹

DEBUG LOG in iOS App
```
2023-04-26 17:18:52.282292+0700 KMMIC[43976:3499509] [AXRuntimeCommon] Unknown client: KMMIC
04-26 17:18:53.366 💚 DEBUG HttpClientCallLogger.closeResponseLog[async] - RESPONSE: 200 OK
METHOD: HttpMethod(value=GET)
FROM: https://survey-api.nimblehq.co/api/v1/surveys?page%5Bnumber%5D=1&page%5Bsize%5D=5
COMMON HEADERS
-> Alt-Svc: h3=":443"; ma=86400, h3-29=":443"; ma=86400
-> Cache-Control: max-age=0, private, must-revalidate
-> Content-Encoding: br
-> Content-Type: application/json; charset=utf-8
-> Date: Wed, 26 Apr 2023 10:18:53 GMT
-> Etag: W/"e894f0cf1a9f2ea4689e8db96997a090"
-> Server: cloudflare
-> Vary: Accept, Accept-Encoding, Origin
-> Via: 1.1 vegur
-> cf-cache-status: DYNAMIC
-> cf-ray: 7bde158d7d36b46c-HKG
-> nel: {"success_fraction":0,"report_to":"cf-nel","max_age":604800}
-> referrer-policy: strict-origin-when-cross-origin
-> report-to: {"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=hs%2BS7IoezTta8b%2FfPlOFAwuDz7v7zcd%2FuQGvLMI4d4b%2Bwor%2FkcuaCMO4Um%2F81NCJAX2ZHeJNxZ2xbZj5chtQMJdnei6pRG%2BAxGkQZPeYnQdnvj5lKTxjRJ9r%2BVguF1ZH%2B31Wu9vkcKF9Kr8HnyI4oJcoG1W1"}],"group":"cf-nel","max_age":604800}
-> x-content-type-options: nosniff
-> x-download-options: noopen
-> x-frame-options: SAMEORIGIN
-> x-permitted-cross-domain-policies: none
-> x-request-id: 268a6989-8d4b-4f5e-8c40-b4b916398137
-> x-runtime: 0.007363
-> x-xss-protection: 0
BODY Content-Type: application/json; charset=utf-8
BODY START
{"data":[{"id":"d5de6a8f8f5f1cfe51bc","type":"survey_simple","attributes":{"title":"Scarlett Bangkok","description":"We'd love ot hear from you!","thank_email_above_threshold":"\u003cspan style=\"font-family:arial,helvetica,sans-serif\"\u003e\u003cspan style=\"font-size:14px\"\u003eDear {name},\u003cbr /\u003e\u003cbr /\u003eThank you for visiting Scarlett Wine Bar \u0026amp; Restaurant at Pullman Bangkok Hotel G \u0026nbsp;and for taking the time to complete our guest feedback survey!\u003cbr /\u003e\u003cbr /\u003eYour feedback is very important to us and each survey is read individually by the management and owners shortly after it is sent. We discuss comments and suggestions at our daily meetings and use them to constantly improve our services.\u003cbr /\u003e\u003cbr /\u003eWe would very much appreciate it if you could take a few more
...
```
