### PR TITLE
[#39] [Integrate] As a user, I can submit my survey response

### DIFF
--- a/ios/KMMIC/Sources/Injection/Container+Domain.swift
+++ b/ios/KMMIC/Sources/Injection/Container+Domain.swift
@@ -27,6 +27,10 @@ extension Container {
         Factory(self) { GetSurveyUseCaseImpl() }
     }
 
+    var submitSurveyUseCase: Factory<SubmitSurveyUseCase> {
+        Factory(self) { SubmitSurveyUseCaseImpl() }
+    }
+
     var dateHelper: Factory<DateHelperProtocol> {
         Factory(self) { DateHelper() }
     }

--- a/ios/KMMIC/Sources/Presentation/Modules/SurveyQuestion/SurveyQuestionScreen.swift
+++ b/ios/KMMIC/Sources/Presentation/Modules/SurveyQuestion/SurveyQuestionScreen.swift
@@ -33,7 +33,7 @@ struct SurveyQuestionScreen: View {
                     Spacer()
                     if viewModel.isLast {
                         PrimaryButton(R.string.localizable.surveyQuestionScreenSubmitButtonTitle()) {
-                            // TODO: Submit survey
+                            viewModel.submitSurvey()
                         }
                         .frame(width: 120.0)
                     } else {
@@ -66,6 +66,13 @@ struct SurveyQuestionScreen: View {
                 secondaryButton: .cancel(Text(R.string.localizable.alertCancelButtonTitle())) {}
             )
         })
+        .alert($viewModel.alertDescription)
+        .progressHUD($viewModel.isLoading)
+        .onChange(of: viewModel.didSubmitSurvey) {
+            guard $0 else { return }
+            // TODO: Show Survey Complete screen
+            print("Survey submitted!!!")
+        }
     }
 
     @ViewBuilder var answerView: some View {

--- a/shared/src/commonMain/kotlin/co/nimblehq/mark/kmmic/data/service/api/ApiService.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/mark/kmmic/data/service/api/ApiService.kt
@@ -81,4 +81,21 @@ internal class ApiService(requiresAuthentication: Boolean = false): KoinComponen
             }
         }
     }
+
+    fun performRequestWithEmptyResponse(builder: HttpRequestBuilder): Flow<Unit> {
+        return flow {
+            val body = httpClient.request(
+                builder.apply {
+                    contentType(ContentType.Application.Json)
+                }
+            ).bodyAsText()
+            try {
+                if (body != "{}") JsonApi(jsonConfigs).decodeFromJsonApiString<Unit>(body)
+                emit(Unit)
+            } catch (e: JsonApiException) {
+                val message = e.errors.first().detail
+                throw ApiError(message)
+            }
+        }
+    }
 }

--- a/shared/src/commonMain/kotlin/co/nimblehq/mark/kmmic/data/service/survey/SurveyService.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/mark/kmmic/data/service/survey/SurveyService.kt
@@ -45,7 +45,7 @@ internal class SurveyServiceImpl: SurveyService, KoinComponent {
     }
 
     override fun submitSurvey(body: SurveySubmissionParams): Flow<Unit> {
-        return apiService.performRequest(
+        return apiService.performRequestWithEmptyResponse(
             HttpRequestBuilder().apply {
                 path("/v1/responses")
                 method = HttpMethod.Post


### PR DESCRIPTION
https://github.com/markgravity/kmm-ic/issues/39

## What happened 👀

- Integrate submit survey function in the Survey Question screen
- Write more tests in `SurveyQuestionViewModelSpec`
- Add `performRequestWithEmptyResponse` to `ApiService`

## Insight 📝

We need to add `performRequestWithEmptyResponse` to handle the empty response from submitting survey API

## Proof Of Work 📹


https://github.com/markgravity/kmm-ic/assets/17875522/ca21c040-bf56-48f6-82c6-c16483a7d95b


