### PR TITLE
[#99] [Part 2] Write UITest for the Login screen

### DIFF
--- a/ios/.sourcery.yml
+++ b/ios/.sourcery.yml
@@ -10,3 +10,5 @@ args:
   autoMockableTestableImports:
     - KMMIC
     - Shared
+  autoMockableImports:
+    - FlowStacks

--- a/ios/KMMIC.xcodeproj/project.pbxproj
+++ b/ios/KMMIC.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		2D66D5F42A11E295006AB0AC /* AutoMockable.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 374A718F62CC6F6121EF0895 /* AutoMockable.generated.swift */; };
 		2D66D5F62A11E426006AB0AC /* XCTestCase+App.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D66D5F52A11E426006AB0AC /* XCTestCase+App.swift */; };
 		2D66D5FA2A11E973006AB0AC /* NavigatorMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D66D5F92A11E973006AB0AC /* NavigatorMock.swift */; };
+		2D66D5FC2A121417006AB0AC /* LoginScreenSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D66D5FB2A121417006AB0AC /* LoginScreenSpec.swift */; };
 		2D89DD7C29F68C1A0093E013 /* AlertDescription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D89DD7B29F68C1A0093E013 /* AlertDescription.swift */; };
 		2D89DD8429F77D480093E013 /* HomeSurveys.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D89DD8329F77D480093E013 /* HomeSurveys.swift */; };
 		2D89DD8629F780270093E013 /* ArrowButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D89DD8529F780270093E013 /* ArrowButton.swift */; };
@@ -183,6 +184,7 @@
 		2D66D5ED2A11D25E006AB0AC /* Rswift+Color.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Rswift+Color.swift"; sourceTree = "<group>"; };
 		2D66D5F52A11E426006AB0AC /* XCTestCase+App.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+App.swift"; sourceTree = "<group>"; };
 		2D66D5F92A11E973006AB0AC /* NavigatorMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigatorMock.swift; sourceTree = "<group>"; };
+		2D66D5FB2A121417006AB0AC /* LoginScreenSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginScreenSpec.swift; sourceTree = "<group>"; };
 		2D89DD7B29F68C1A0093E013 /* AlertDescription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertDescription.swift; sourceTree = "<group>"; };
 		2D89DD8329F77D480093E013 /* HomeSurveys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeSurveys.swift; sourceTree = "<group>"; };
 		2D89DD8529F780270093E013 /* ArrowButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrowButton.swift; sourceTree = "<group>"; };
@@ -581,6 +583,7 @@
 			isa = PBXGroup;
 			children = (
 				2DBC460A2A0DDE6F00356B34 /* SplashSpec.swift */,
+				2D66D5FB2A121417006AB0AC /* LoginScreenSpec.swift */,
 			);
 			path = Module;
 			sourceTree = "<group>";
@@ -1531,6 +1534,7 @@
 				2D66D5F42A11E295006AB0AC /* AutoMockable.generated.swift in Sources */,
 				2D66D5F62A11E426006AB0AC /* XCTestCase+App.swift in Sources */,
 				4B11F4DF6B794BA665067110 /* KIF+Swift.swift in Sources */,
+				2D66D5FC2A121417006AB0AC /* LoginScreenSpec.swift in Sources */,
 				2D66D5FA2A11E973006AB0AC /* NavigatorMock.swift in Sources */,
 				2DBC46142A0DE14100356B34 /* ViewID.swift in Sources */,
 				2DBC460C2A0DDE8000356B34 /* SplashSpec.swift in Sources */,

--- a/ios/KMMIC/Sources/Constants/ViewID/ViewID.swift
+++ b/ios/KMMIC/Sources/Constants/ViewID/ViewID.swift
@@ -10,17 +10,33 @@ import Foundation
 
 enum ViewID {
 
+    case general(General)
     case splash(Splash)
+    case login(Login)
+
+    enum General: String {
+        case progressHUD = "general.progressHUD"
+    }
 
     enum Splash: String {
         case background = "splash.background"
         case logo = "splash.logo"
     }
 
+    enum Login: String {
+        case emailField = "login.emailField"
+        case passwordField = "login.passwordField"
+        case loginButton = "login.logInButton"
+    }
+
     func callAsFunction() -> String {
         switch self {
+        case let .general(general):
+            return general.rawValue
         case let .splash(splash):
             return splash.rawValue
+        case let .login(login):
+            return login.rawValue
         }
     }
 }

--- a/ios/KMMIC/Sources/Injection/Container+Domain.swift
+++ b/ios/KMMIC/Sources/Injection/Container+Domain.swift
@@ -38,4 +38,8 @@ extension Container {
     var navigator: Factory<Navigator> {
         Factory(self) { Navigator() }.scope(.singleton)
     }
+
+    var loginViewModel: Factory<LoginViewModel> {
+        Factory(self) { LoginViewModel() }
+    }
 }

--- a/ios/KMMIC/Sources/Presentation/Modules/Login/LoginScreen.swift
+++ b/ios/KMMIC/Sources/Presentation/Modules/Login/LoginScreen.swift
@@ -6,46 +6,24 @@
 //  Copyright © 2023 Nimble. All rights reserved.
 //
 
+import Factory
 import SwiftUI
 
 struct LoginScreen: View {
 
     @State private var isAnimated = false
 
-    @EnvironmentObject private var navigator: Navigator
-    @StateObject private var viewModel = LoginViewModel()
+    @InjectedObject(\.navigator) private var navigator: Navigator
+    @InjectedObject(\.loginViewModel) private var viewModel: LoginViewModel
 
     var body: some View {
         ZStack {
             PrimaryDimmedBackground(isAnimated: isAnimated)
             R.image.logoWhite.image
                 .offset(x: 0.0, y: isAnimated ? -230.0 : 0.0)
-            VStack {
-                PrimaryTextField(
-                    R.string.localizable.loginScreenEmailTextFieldTitle(),
-                    text: $viewModel.email
-                )
-                .keyboardType(.emailAddress)
-                .padding(.bottom, 20.0)
-                PrimaryTextField(
-                    R.string.localizable.loginScreenPasswordTextFieldTitle(),
-                    text: $viewModel.password,
-                    isSecured: true
-                ) {
-                    Button(R.string.localizable.loginScreenForgotButtonTitle()) {
-                        // TODO: Show ForgotPassword screen
-                    }
-                    .foregroundColor(.white.opacity(0.5))
-                }
-                .padding(.bottom, 20.0)
-                PrimaryButton(R.string.localizable.loginScreenLoginButtonTitle()) {
-                    viewModel.login()
-                }
-                .disabled(!viewModel.isAllValidated)
-                .frame(height: 56.0)
-            }
-            .opacity(isAnimated ? 1.0 : 0.0)
-            .padding(.horizontal, 24.0)
+            VStack { formView }
+                .opacity(isAnimated ? 1.0 : 0.0)
+                .padding(.horizontal, 24.0)
         }
         .ignoresSafeArea()
         .alert($viewModel.alertDescription)
@@ -58,6 +36,34 @@ struct LoginScreen: View {
             guard $0 else { return }
             navigator.show(screen: .home, by: .root)
         }
+    }
+
+    @ViewBuilder var formView: some View {
+        PrimaryTextField(
+            R.string.localizable.loginScreenEmailTextFieldTitle(),
+            text: $viewModel.email
+        )
+        .keyboardType(.emailAddress)
+        .padding(.bottom, 20.0)
+        .accessibility(.login(.emailField))
+        PrimaryTextField(
+            R.string.localizable.loginScreenPasswordTextFieldTitle(),
+            text: $viewModel.password,
+            isSecured: true
+        ) {
+            Button(R.string.localizable.loginScreenForgotButtonTitle()) {
+                // TODO: Show ForgotPassword screen
+            }
+            .foregroundColor(.white.opacity(0.5))
+        }
+        .padding(.bottom, 20.0)
+        .accessibility(.login(.passwordField))
+        PrimaryButton(R.string.localizable.loginScreenLoginButtonTitle()) {
+            viewModel.login()
+        }
+        .disabled(!viewModel.isAllValidated)
+        .frame(height: 56.0)
+        .accessibility(.login(.loginButton))
     }
 }
 

--- a/ios/KMMIC/Sources/Presentation/Modules/Login/LoginViewModel.swift
+++ b/ios/KMMIC/Sources/Presentation/Modules/Login/LoginViewModel.swift
@@ -9,7 +9,8 @@
 import Combine
 import Factory
 
-final class LoginViewModel: ObservableObject {
+// sourcery: AutoMockable
+class LoginViewModel: ObservableObject {
 
     @Injected(\.loginUseCase) private var loginUseCase
 

--- a/ios/KMMIC/Sources/Presentation/Views/ProgressHUD.swift
+++ b/ios/KMMIC/Sources/Presentation/Views/ProgressHUD.swift
@@ -52,6 +52,7 @@ struct ProgressHUD: View {
         .ignoresSafeArea()
         .opacity(isPresented ? 1.0 : 0.0)
         .animation(.easeIn(duration: 0.3), value: isPresented)
+        .accessibility(.general(.progressHUD))
     }
 }
 

--- a/ios/KMMICKIFUITests/Sources/Specs/Presentation/Module/LoginScreenSpec.swift
+++ b/ios/KMMICKIFUITests/Sources/Specs/Presentation/Module/LoginScreenSpec.swift
@@ -1,0 +1,92 @@
+//
+//  LoginScreenSpec.swift
+//  KMMICKIFUITests
+//
+//  Created by MarkG on 15/05/2023.
+//  Copyright © 2023 Nimble. All rights reserved.
+//
+
+import Factory
+import Nimble
+import Quick
+
+@testable import KMMIC
+
+final class LoginScreenSpec: QuickSpec {
+
+    override func spec() {
+
+        describe("a LoginScreen screen") {
+
+            var navigator: NavigatorMock!
+            var viewModel: LoginViewModelMock!
+            var didSetScreen = false
+
+            beforeEach {
+                guard !didSetScreen else { return }
+                didSetScreen = true
+                navigator = .init()
+                viewModel = .init()
+
+                Container.shared.loginViewModel.register {
+                    viewModel
+                }
+                self.app().setScreen(screen: .login, navigator: navigator)
+                self.tester().waitForAnimationsToFinish(withTimeout: 5.0, stabilizationTime: 10.0)
+            }
+
+            it("has email field") {
+                self.tester().waitForView(withViewID: .login(.emailField))
+            }
+
+            it("has password field") {
+                self.tester().waitForView(withViewID: .login(.passwordField))
+            }
+
+            it("has login button") {
+                self.tester().waitForView(withViewID: .login(.loginButton))
+            }
+
+            describe("its login button tap") {
+
+                beforeEach {
+                    viewModel.underlyingIsAllValidated = true
+                    viewModel.objectWillChange.send()
+                    self.tester().waitForAnimationsToFinish()
+                    self.tester().tapView(withViewID: .login(.loginButton))
+                }
+
+                it("triggers viewModel to call login()") {
+                    expect(viewModel.loginCalled) == true
+                }
+            }
+
+            context("when viewModel.didLogin is true") {
+
+                beforeEach {
+                    viewModel.underlyingDidLogin = true
+                    viewModel.objectWillChange.send()
+                    self.tester().waitForAnimationsToFinish()
+                }
+
+                it("triggers navigator to show the Home screen") {
+                    expect(navigator.showScreenByReceivedArguments?.screen)
+                        .toEventually(equal(.home))
+                }
+            }
+
+            context("when viewModel.isLoading is true") {
+
+                beforeEach {
+                    viewModel.underlyingIsLoading = true
+                    viewModel.objectWillChange.send()
+                    self.tester().waitForAnimationsToFinish()
+                }
+
+                it("shows Progress HUD") {
+                    self.tester().waitForView(withViewID: .general(.progressHUD))
+                }
+            }
+        }
+    }
+}

--- a/ios/KMMICKIFUITests/Sources/Specs/Presentation/Module/SplashSpec.swift
+++ b/ios/KMMICKIFUITests/Sources/Specs/Presentation/Module/SplashSpec.swift
@@ -18,8 +18,12 @@ final class SplashSpec: QuickSpec {
         describe("a Splash screen") {
 
             var navigator: NavigatorMock!
+            var didSetScreen = false
 
-            beforeSuite {
+            beforeEach {
+                guard !didSetScreen else { return }
+                didSetScreen = true
+
                 navigator = .init()
                 self.app().setScreen(screen: .splash, navigator: navigator)
                 self.tester().waitForAnimationsToFinish()

--- a/ios/KMMICKIFUITests/Sources/Utilities/Tester+ViewID.swift
+++ b/ios/KMMICKIFUITests/Sources/Utilities/Tester+ViewID.swift
@@ -15,6 +15,10 @@ extension KIFUITestActor {
         waitForView(withAccessibilityIdentifier: viewID())
     }
 
+    func waitForTappableView(withViewID viewID: ViewID) {
+        waitForTappableView(withAccessibilityIdentifier: viewID())
+    }
+
     func enterText(_ text: String, intoViewWithViewID viewID: ViewID) {
         enterText(text, intoViewWithAccessibilityIdentifier: viewID())
     }

--- a/ios/KMMICKIFUITests/Sources/Utilities/XCTestCase+App.swift
+++ b/ios/KMMICKIFUITests/Sources/Utilities/XCTestCase+App.swift
@@ -13,8 +13,11 @@ import XCTest
 
 class App {
 
+    static var originNavigator: Navigator?
+
     func setScreen(screen: Navigator.Screen, navigator: Navigator? = nil) {
-        let originNavigator = Container.shared.navigator()
+        let originNavigator = Self.originNavigator ?? Container.shared.navigator()
+        Self.originNavigator = originNavigator
         if let navigator = navigator {
             Container.shared.navigator.register {
                 navigator

--- a/ios/tools/sourcery/templates/AutoMockable.stencil
+++ b/ios/tools/sourcery/templates/AutoMockable.stencil
@@ -47,7 +47,7 @@ import {{ import }}
 
 {% macro methodClosureCallParameters method %}{% for param in method.parameters %}{{ param.name }}{% if not forloop.last %}, {% endif %}{% endfor %}{% endmacro %}
 
-{% macro mockMethod method %}
+{% macro mockMethod method modifiers %}
     //MARK: - {{ method.shortName }}
 
     {% if method.throws %}
@@ -72,11 +72,13 @@ import {{ import }}
     {% call methodClosureDeclaration method %}
 
 {% if method.isInitializer %}
+    {{ modifiers }}
     required {{ method.name }} {
         {% call methodReceivedParameters method %}
         {% call methodClosureName method %}?({% call methodClosureCallParameters method %})
     }
 {% else %}
+    {{ modifiers }}
     func {{ method.name }}{{ ' throws' if method.throws }}{% if not method.returnTypeName.isVoid %} -> {{ method.returnTypeName }}{% endif %} {
         {% if method.throws %}
         {% call methodThrowableErrorUsage method %}
@@ -106,7 +108,7 @@ import {{ import }}
         get { return {% call underlyingMockedVariableName variable %} }
         set(value) { {% call underlyingMockedVariableName variable %} = value }
     }
-    var {% call underlyingMockedVariableName variable %}: {{ variable.typeName }}!
+    var {% call underlyingMockedVariableName variable %}: {{ variable.typeName }}{% if not variable.isOptional %}!{% endif %}{% if variable.defaultValue %} = {{ variable.defaultValue}}{% endif %}
 {% endmacro %}
 
 {% macro underlyingMockedVariableName variable %}underlying{{ variable.name|upperFirstLetter }}{% endmacro %}
@@ -120,8 +122,27 @@ class {{ type.name }}Mock: {{ type.name }} {
 
 {% for method in type.allMethods|!definedInExtension %}
     {% if method.attributes.available[0].arguments.renamed == null %}
-    {% call mockMethod method %}
+    {% call mockMethod method "" %}
     {% endif %}
+{% endfor %}
+}
+
+{% endif %}{% endfor %}
+
+{% for type in types.classes where type.based.AutoMockable or type|annotated:"AutoMockable" %}{% if type.name != "AutoMockable" %}
+class {{ type.name }}Mock: {{ type.name }} {
+{% for variable in type.allVariables|!definedInExtension %}
+{% if variable.readAccess != "private" and variable.readAccess != "fileprivate" %}
+    override {% if variable.isArray or variable.isDictionary %}{% call mockNonOptionalArrayOrDictionaryVariable variable %}{% else %}{% call mockNonOptionalVariable variable %}{% endif %}
+{% endif %}
+{% endfor %}
+
+{% for method in type.allMethods|!definedInExtension %}
+{% if method.attributes.available[0].arguments.renamed == null %}
+{% if method.readAccess != "private" and method.readAccess != "fileprivate" %}
+{% call mockMethod method "override" %}
+{% endif %}
+{% endif %}
 {% endfor %}
 }
 

--- a/ios/tools/sourcery/templates/AutoMockable.stencil
+++ b/ios/tools/sourcery/templates/AutoMockable.stencil
@@ -47,9 +47,8 @@ import {{ import }}
 
 {% macro methodClosureCallParameters method %}{% for param in method.parameters %}{{ param.name }}{% if not forloop.last %}, {% endif %}{% endfor %}{% endmacro %}
 
-{% macro mockMethod method modifiers %}
-    //MARK: - {{ method.shortName }}
-
+{% macro mockMethod method isClass %}
+    // MARK: - {{ method.shortName }}
     {% if method.throws %}
         {% call methodThrowableErrorDeclaration method %}
     {% endif %}
@@ -72,13 +71,14 @@ import {{ import }}
     {% call methodClosureDeclaration method %}
 
 {% if method.isInitializer %}
-    {{ modifiers }}
+    {% if isClass %}override{% endif %}
     required {{ method.name }} {
         {% call methodReceivedParameters method %}
         {% call methodClosureName method %}?({% call methodClosureCallParameters method %})
     }
+
 {% else %}
-    {{ modifiers }}
+    {% if isClass %}override{% endif %}
     func {{ method.name }}{{ ' throws' if method.throws }}{% if not method.returnTypeName.isVoid %} -> {{ method.returnTypeName }}{% endif %} {
         {% if method.throws %}
         {% call methodThrowableErrorUsage method %}
@@ -114,36 +114,50 @@ import {{ import }}
 {% macro underlyingMockedVariableName variable %}underlying{{ variable.name|upperFirstLetter }}{% endmacro %}
 {% macro mockedVariableName variable %}{{ variable.name }}{% endmacro %}
 
-{% for type in types.protocols where type.based.AutoMockable or type|annotated:"AutoMockable" %}{% if type.name != "AutoMockable" %}
+{% for type in types.protocols where type.based.AutoMockable or type|annotated:"AutoMockable" %}
+    {% if type.name != "AutoMockable" %}
 class {{ type.name }}Mock: {{ type.name }} {
-{% for variable in type.allVariables|!definedInExtension %}
-    {% if variable.isOptional %}{% call mockOptionalVariable variable %}{% elif variable.isArray or variable.isDictionary %}{% call mockNonOptionalArrayOrDictionaryVariable variable %}{% else %}{% call mockNonOptionalVariable variable %}{% endif %}
-{% endfor %}
+        {% for variable in type.allVariables|!definedInExtension %}
+            {% if variable.isOptional %}
+                {% call mockOptionalVariable variable %}
+            {% elif variable.isArray or variable.isDictionary %}
+                {% call mockNonOptionalArrayOrDictionaryVariable variable %}
+            {% else %}
+                {% call mockNonOptionalVariable variable %}
+            {% endif %}
+        {% endfor %}
 
-{% for method in type.allMethods|!definedInExtension %}
-    {% if method.attributes.available[0].arguments.renamed == null %}
-    {% call mockMethod method "" %}
+        {% for method in type.allMethods|!definedInExtension %}
+            {% if method.attributes.available[0].arguments.renamed == null %}
+                {% call mockMethod method false %}
+            {% endif %}
+        {% endfor %}
+}
+
     {% endif %}
 {% endfor %}
-}
 
-{% endif %}{% endfor %}
-
-{% for type in types.classes where type.based.AutoMockable or type|annotated:"AutoMockable" %}{% if type.name != "AutoMockable" %}
+{% for type in types.classes where type.based.AutoMockable or type|annotated:"AutoMockable" %}
+    {% if type.name != "AutoMockable" %}
 class {{ type.name }}Mock: {{ type.name }} {
-{% for variable in type.allVariables|!definedInExtension %}
-{% if variable.readAccess != "private" and variable.readAccess != "fileprivate" %}
-    override {% if variable.isArray or variable.isDictionary %}{% call mockNonOptionalArrayOrDictionaryVariable variable %}{% else %}{% call mockNonOptionalVariable variable %}{% endif %}
-{% endif %}
-{% endfor %}
+        {% for variable in type.allVariables|!definedInExtension %}
+            {% if variable.readAccess != "private" and variable.readAccess != "fileprivate" %}
 
-{% for method in type.allMethods|!definedInExtension %}
-{% if method.attributes.available[0].arguments.renamed == null %}
-{% if method.readAccess != "private" and method.readAccess != "fileprivate" %}
-{% call mockMethod method "override" %}
-{% endif %}
-{% endif %}
-{% endfor %}
+    override
+                {% if variable.isArray or variable.isDictionary %}
+                    {% call mockNonOptionalArrayOrDictionaryVariable variable %}
+                {% else %}
+                    {% call mockNonOptionalVariable variable %}
+                {% endif %}
+            {% endif %}
+        {% endfor %}
+
+        {% for method in type.allMethods|!definedInExtension %}
+            {% if method.attributes.available[0].arguments.renamed == null and method.readAccess != "private" and method.readAccess != "fileprivate" %}
+                {% call mockMethod method true %}
+            {% endif %}
+        {% endfor %}
 }
 
-{% endif %}{% endfor %}
+    {% endif %}
+{% endfor %}


### PR DESCRIPTION
https://github.com/markgravity/kmm-ic/issues/99

## What happened 👀

- Support to run all the UITest files
- Write UITest for the Login screen
- Update `Automockable.stencil` to generate a mock class for ViewModel

## Insight 📝

We are unable to test the Alert when we update the `View+Alert.swift` like below, all other tests will be failed.  
```swift
extension View {

    func alert(_ alertDescription: Binding<AlertDescription?>) -> some View {
        alert(item: alertDescription) {
            Alert(
                title: Text($0.title),
                message: Text($0.message)
            )
        }
        .accessibility(.general(.alert))
    }
}
```
I will investigate this issue further later

## Proof Of Work 📹

![CleanShot 2023-05-16 at 10 37 56](https://github.com/markgravity/kmm-ic/assets/17875522/96908cf6-de57-4c4c-b1eb-1988d800978a)

